### PR TITLE
Travis: only build branch builds on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache: yarn
 
 install: yarn --frozen-lockfile
 
+# See http://stackoverflow.com/questions/31882306
+branches:
+  only: 
+    - master
+
 script: ember build
 
 deploy:


### PR DESCRIPTION
Travis has two types of builds:

 1. Pull Request builds get run on branches other than master
 2. Branch builds run on any push to any branch

We enable both in settings, but only run the latter on master. This makes it so pull requests get pull request builds and master gets a branch build (on merge), but branches don't get _two_ builds (a Pull Request build and a Branch build).