### PR TITLE
fix CSS pipeline for prod builds in ember-cli-build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,19 +3,24 @@
 const GlimmerApp = require('@glimmer/application-pipeline').GlimmerApp;
 const MergeTrees = require('broccoli-merge-trees');
 const Concat = require('broccoli-concat');
+const Funnel = require('broccoli-funnel');
+
+class CustomApp extends GlimmerApp {
+  cssTree() {
+    const cssTree = super.cssTree();
+
+    const styles = new Funnel('node_modules', {
+      files: ['todomvc-app-css/index.css']
+    });
+
+    return Concat(new MergeTrees([cssTree, styles]), {
+      outputFile: 'app.css'
+    });
+  }
+}
 
 module.exports = function(defaults) {
-  const app = new GlimmerApp(defaults, {
-    // Add options here
-  });
-
-  const styles = Concat('node_modules', {
-    inputFiles: [
-      'todomvc-app-css/index.css',
-      'todomvc-common/base.css',
-    ],
-    outputFile: 'app.css',
-  });
+  const app = new CustomApp(defaults);
 
   const vendorScripts = Concat('node_modules', {
     inputFiles: ['todomvc-common/base.js'],
@@ -24,7 +29,6 @@ module.exports = function(defaults) {
 
   return new MergeTrees([
     app.toTree(),
-    styles,
     vendorScripts
   ], { overwrite: true });
-};
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@glimmer/component": "^0.3.8",
     "@glimmer/resolver": "^0.3.0",
     "broccoli-concat": "^3.2.2",
+    "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli": "2.12.1",
     "ember-cli-inject-live-reload": "^1.6.1",
@@ -25,8 +26,8 @@
   },
   "private": true,
   "dependencies": {
+    "navigo": "^4.5.1",
     "todomvc-app-css": "^2.1.0",
-    "todomvc-common": "^1.0.3",
-    "navigo": "^4.5.1"
+    "todomvc-common": "^1.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,7 +1140,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.1.0.tgz#dfb91a37c902456456de4a40a1881948d65b27d9"
   dependencies:


### PR DESCRIPTION
This PR address the issue reported [here](https://github.com/glimmerjs/glimmer-application-pipeline/issues/74#issuecomment-292790467) and [here](https://github.com/glimmerjs/todomvc-demo/issues/19).

It fixes the CSS issue by extending the `cssTree` method of `GlimmerApp` and incorporating the external CSS using a broccoli funnel.

As I see it, there are (possibly) two outstanding issues here:

1. It seems like this same approach will need to be done for the javascript files, but I'm not sure what `todo-mvc-base` is supposed to do and the app doesn't appear to be missing any js-related functionality when you boot it...so maybe it's fine?

2. This approach means that you aren't explicitly importing the external css into `app.scss` and letting it resolve from there. IMO this would be preferable since it's a lot more explicit. I worked out an approach that allowed for this (by just using `broccoli-funnel` without `broccoli-concat` and merging the funnel with `cssTree`), but this resulted into two css files being output in the `dist` folder, which doesn't seem great.

Anyway, the CSS works in prod builds now!